### PR TITLE
Fix hot reloading when running through the proxy

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
 PORT=4200
 BROWSER=none
-WDS_SOCKET_PORT=443
 REACT_APP_BANKING_API_URL=https://localhost/api/banking
 REACT_APP_USER_API_URL=https://localhost/api/user
 REACT_APP_TRADING_API_URL=https://localhost/api/trading

--- a/.env
+++ b/.env
@@ -1,4 +1,6 @@
 PORT=4200
+BROWSER=none
+WDS_SOCKET_PORT=443
 REACT_APP_BANKING_API_URL=https://localhost/api/banking
 REACT_APP_USER_API_URL=https://localhost/api/user
 REACT_APP_TRADING_API_URL=https://localhost/api/trading

--- a/Caddyfile
+++ b/Caddyfile
@@ -15,6 +15,11 @@ localhost {
 	  reverse_proxy trading-service:3000
 	}
 
+  @websockets {
+    header Connection *Upgrade*
+    header Upgrade websocket
+  }
+	reverse_proxy @websockets host.docker.internal:4200
 	handle {
 		# Frontend
 		reverse_proxy host.docker.internal:4200

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "cypress": "^14.2.0",
+    "eslint-config-react-app": "^7.0.1",
     "jest": "^27.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:proxy": "cross-env WDS_SOCKET_PORT=443 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -55,6 +56,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
+    "cross-env": "^7.0.3",
     "cypress": "^14.2.0",
     "eslint-config-react-app": "^7.0.1",
     "jest": "^27.5.1"


### PR DESCRIPTION
Also stops CRA from opening the browser on startup. 

To run the app with hot reloading through the proxy you need to run:
```shell
npm start:proxy
```